### PR TITLE
Manifest file format seems to have changed, no longer works to download data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hmp_client
 
-Python-based client for downloading data files hosted by the Human Microbiome Data Analysis and Coordination Center (hmpdacc.org). The client accepts as input a *manifest file* that lists the files to be downloaded. Manifest files can be generated using the shopping cart in the query interface at https://portal.hmpdacc.org.
+Python-based client for downloading data files hosted by the Human Microbiome Data Analysis and Coordination Center (hmpdacc.org). The client accepts as input a *manifest file* that lists the files to be downloaded. Manifest files can be generated using the shopping cart in the query interface at https://portal.hmpdacc.org. An example manifest file can be found in the [test](https://github.com/mbonsma/hmp_client/blob/master/test/hmp_cart_example.tsv) folder.
 
 ## Running the client
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hmp_client
 
-Python-based client for downloading data files hosted by the Human Microbiome Data Analysis and Coordination Center (hmpdacc.org). The client accepts as input a *manifest file* that lists the files to be downloaded. Manifest files can be generated using the shopping cart in the query interface at https://portal.hmpdacc.org. An example manifest file can be found in the [test](https://github.com/mbonsma/hmp_client/blob/master/test/hmp_cart_example.tsv) folder.
+Python-based client for downloading data files hosted by the Human Microbiome Data Analysis and Coordination Center (hmpdacc.org). The client accepts as input a *manifest file* that lists the files to be downloaded. Manifest files can be generated using the shopping cart in the query interface at https://portal.hmpdacc.org. An example manifest file can be found in the [test](https://github.com/ihmpdcc/hmp_client/blob/master/test/hmp_cart_example.tsv) folder.
 
 ## Running the client
 


### PR DESCRIPTION
This should really be an issue and not a PR. I just made a dummy change to the README, please don't feel obliged to accept it. Can you please enable your issue tracker or include information on how to report bugs or suggest changes?

Here's my issue in more detail: 

I downloaded a manifest file from the [portal](https://portal.hmpdacc.org/) by clicking on `Download Manifest` with two files in my cart. The manifest looks like this:

```
file_id	md5	size	urls	sample_id
2341f5d5c8b48ad8e3ba519f219af9ce	d73c6b97b59df9c4303c292992948d58	26019	fasp://aspera.ihmpdcc.org/ibd/genome/microbiome/wgs/analysis/hmscp/CSM5MCYS_taxonomic_profile.biom	2341f5d5c8b48ad8e3ba519f219ad348
2341f5d5c8b48ad8e3ba519f219aee12	fb9f7aeaabf5b647a018f113d696b4cd	20042292	fasp://aspera.ihmpdcc.org/ibd/genome/microbiome/wgs/raw/CSM5MCYS.tar	2341f5d5c8b48ad8e3ba519f219ad348
```

By comparison with the [test](https://github.com/ihmpdcc/hmp_client/tree/master/test) folder, the link format is different? I got this error when I ran `./bin/hmp_client -manifest ../../../Downloads/hmp_cart_5d75680.tsv `
```
No valid URL found in the manifest for file ID 2341f5d5c8b48ad8e3ba519f219af9ce
No valid URL found in the manifest for file ID 2341f5d5c8b48ad8e3ba519f219aee12

Not all files in manifest (total of 2) were downloaded successfully. Number of failures:
2 -- no valid URL in the manifest file
0 -- URL present in manifest, but not accessible at the location specified
0 -- MD5 check failed for file (file is corrupted or the wrong MD5 is attached to the file
```

Any help would be much appreciated! 